### PR TITLE
Add remaining IBM Debater CSV datasets

### DIFF
--- a/datasets.yaml
+++ b/datasets.yaml
@@ -36,7 +36,7 @@ datasets:
             columns:
               Concept: 'string'
               Score: 'float'
-          path: concept_abstractness/prediction_unigrams.csv
+          path: prediction_unigrams.csv
         bigrams:
           name: Bigrams
           description: "Bigram Wikipedia Article Titles with their abstractness score"
@@ -45,7 +45,7 @@ datasets:
             columns:
               Concept: 'string'
               Score: 'float'
-          path: concept_abstractness/prediction_bigrams.csv
+          path: prediction_bigrams.csv
         trigrams:
           name: Trigrams
           description: "Trigram Wikipedia Article Titles with their abstractness score"
@@ -54,7 +54,7 @@ datasets:
             columns:
               Concept: 'string'
               Score: 'float'
-          path: concept_abstractness/prediction_trigrams.csv
+          path: prediction_trigrams.csv
   gmb:
     "1.0.2":
       name: Groningen Meaning Bank Modified
@@ -137,7 +137,7 @@ datasets:
               columns:
                 UNIGRAM: 'string'
                 SENTIMENT_SCORE: 'float'
-          path: sentiment_compositions_lexicon/LEXICON_UG.txt
+          path: LEXICON_UG.txt
         bigrams:
           name: Bigrams Sentiment Lexicon
           description: Bigrams with their POS tag and sentiment score
@@ -148,16 +148,7 @@ datasets:
                 BIGRAM: 'string'
                 POS_TAG: 'string'
                 SENTIMENT_SCORE: 'float'
-          path: sentiment_compositions_lexicon/LEXICON_BG.txt
-        semantic_classes:
-          name: Semantic Classes
-          description: The composition lexicons for reversers, propagators, and dominators
-          format:
-            id: xslx
-            options:
-              columns:
-                class: 'string'
-          path: sentiment_compositions_lexicon/SEMANTIC_CLASSES.xlsx
+          path: LEXICON_BG.txt
   thematic_clustering_of_sentences:
     "1.0.2":
       name: IBM Debater® Thematic Clustering of Sentences
@@ -179,7 +170,7 @@ datasets:
                 sentence: 'string'
                 cluster_title: 'string'
                 article_link: 'string'
-          path: thematic-clustering-of-sentences/dataset.csv
+          path: dataset.csv
   wikipedia_category_stance:
     "1.0.2":
       name: IBM Debater® Wikipedia Category Stance
@@ -202,7 +193,7 @@ datasets:
                 Concept: 'string'
                 Category: 'string'
                 URL: 'string'
-          path: wikipedia_category_stance/WikipediaCategoriesResults.csv
+          path: WikipediaCategoriesResults.csv
   wikipedia_oriented_relatedness:
     "1.0.2":
       name: IBM Debater® Wikipedia Oriented Relatedness
@@ -219,6 +210,7 @@ datasets:
           format:
             id: csv
             options:
+              encoding: 'ISO-8859-1'
               columns:
                 source_article_uri: 'string'
                 concept_1: 'string'
@@ -227,4 +219,4 @@ datasets:
                 concept_1_uri: 'string'
                 concept_2_uri: 'string'
                 train_test: 'string'
-          path: wikipedia_oriented_relatedness/WORD.csv
+          path: WORD.csv

--- a/datasets.yaml
+++ b/datasets.yaml
@@ -17,6 +17,44 @@
 api_name: com.ibm.pydax.v1
 last_updated: 2020-10-08
 datasets:
+  concept_abstractness:
+    "1.0.2":
+      name: IBM Debater® Concept Abstractness
+      published: 2019-07-29
+      homepage: https://developer.ibm.com/exchanges/data/all/concept-abstractness/
+      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-concept-abstractness/1.0.2/concept-abstractness.tar.gz
+      sha512sum: 25cb76c0a8fdfc9cae7e050d4c2492bf055f97a20fa85690b9aaf7dcf965a705fc89e32aed7fbb6d418432e5368cb06fc3bb0f1ab85807fec8aef9df3965cc06 
+      license: cc_by_sa_30
+      estimated_size: 3.6M
+      description: "A set of concepts from Wikipedia rated for their degree of abstractness."
+      subdatasets:
+        unigrams:
+          name: Unigrams
+          description: "Unigram Wikipedia Article Titles with their abstractness score"
+          format: csv
+          options:
+            columns:
+              Concept: 'string'
+              Score: 'float'
+          path: concept_abstractness/prediction_unigrams.csv
+        bigrams:
+          name: Bigrams
+          description: "Bigram Wikipedia Article Titles with their abstractness score"
+          format: csv
+          options:
+            columns:
+              Concept: 'string'
+              Score: 'float'
+          path: concept_abstractness/prediction_bigrams.csv
+        trigrams:
+          name: Trigrams
+          description: "Trigram Wikipedia Article Titles with their abstractness score"
+          format: csv
+          options:
+            columns:
+              Concept: 'string'
+              Score: 'float'
+          path: concept_abstractness/prediction_trigrams.csv
   gmb:
     "1.0.2":
       name: Groningen Meaning Bank Modified
@@ -79,3 +117,114 @@ datasets:
               columns:
                 DATE: 'date'
           path: noaa-weather-data-jfk-airport/jfk_weather_cleaned.csv
+  sentiment_compositions_lexicon:
+    "1.0.2":
+      name: IBM Debater® Sentiment Compositions Lexicon
+      published: 2019-10-01
+      homepage: https://developer.ibm.com/exchanges/data/all/sentiment-composition-lexicons/
+      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-sentiment-composition-lexicons/1.0.2/sentiment-composition-lexicons.tar.gz
+      sha512sum: 550da933b668270d890a4e12160202671894c357927e52250500e97b78965d7f3d4506396f9f21f50683a2fc54a4af5922f7fdd0ac7f01e4b5a2f1068451a519
+      license: cc_by_sa_30
+      estimated_size: 10M
+      description: "A dataset on the sentiment of phrases from the interaction between its constituents."
+      subdatasets:
+        unigrams:
+          name: Unigrams Sentiment Lexicon
+          description: Unigrams with their sentiment score
+          format:
+            id: txt
+            options:
+              columns:
+                UNIGRAM: 'string'
+                SENTIMENT_SCORE: 'float'
+          path: sentiment_compositions_lexicon/LEXICON_UG.txt
+        bigrams:
+          name: Bigrams Sentiment Lexicon
+          description: Bigrams with their POS tag and sentiment score
+          format:
+            id: txt
+            options:
+              columns:
+                BIGRAM: 'string'
+                POS_TAG: 'string'
+                SENTIMENT_SCORE: 'float'
+          path: sentiment_compositions_lexicon/LEXICON_BG.txt
+        semantic_classes:
+          name: Semantic Classes
+          description: The composition lexicons for reversers, propagators, and dominators
+          format:
+            id: xslx
+            options:
+              columns:
+                class: 'string'
+          path: sentiment_compositions_lexicon/SEMANTIC_CLASSES.xlsx
+  thematic_clustering_of_sentences:
+    "1.0.2":
+      name: IBM Debater® Thematic Clustering of Sentences
+      published: 2019-08-01
+      homepage: https://developer.ibm.com/exchanges/data/all/thematic-clustering-of-sentences/
+      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-thematic-clustering-of-sentences/1.0.2/thematic-clustering-of-sentences.tar.gz
+      sha512sum: 08a3f1a9dc06083eb51874e90d7241f67b676af2cbc28fe6a312694051f53391fc95de70fdcdce404de3578fa389558220ea38d34f70265ed88220d0b14f1aba
+      estimated_size: 10.6M
+      description: "A benchmark of sentence-clustering based on the partition of Wikipedia articles into sections."
+      subdatasets:
+        full:
+          name: IBM Debater® Thematic Clustering of Sentences
+          description: IBM Debater® Thematic Clustering of Sentences complete dataset
+          format:
+            id: csv
+            options:
+              columns:
+                article_title: 'string'
+                sentence: 'string'
+                cluster_title: 'string'
+                article_link: 'string'
+          path: thematic-clustering-of-sentences/dataset.csv
+  wikipedia_category_stance:
+    "1.0.2":
+      name: IBM Debater® Wikipedia Category Stance
+      published: 2019-08-01
+      homepage: https://developer.ibm.com/exchanges/data/all/wikipedia-category-stance/
+      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-wikipedia-category-stance/1.0.2/wikipedia-category-stance.tar.gz
+      sha512sum: a8e056737699a5a52ef5b7bd91f13f9a672e091b7636010cdcc0ba9d34c322dd761c50bdda01fe988ed6650470f9410ef9f8789e54c4d90124606f7a889f57b4
+      license: cc_by_30
+      estimated_size: 525K
+      description: "Wikipedia categories and lists annotated for stance (Pro/Con) towards the concepts"
+      subdatasets:
+        full:
+          name: IBM Debater® Wikipedia Category Stance Dataset
+          description: IBM Debater® Wikipedia Category Stance complete dataset
+          format:
+            id: csv
+            options:
+              columns:
+                Label: 'string'
+                Concept: 'string'
+                Category: 'string'
+                URL: 'string'
+          path: wikipedia_category_stance/WikipediaCategoriesResults.csv
+  wikipedia_oriented_relatedness:
+    "1.0.2":
+      name: IBM Debater® Wikipedia Oriented Relatedness
+      published: 2019-08-01
+      homepage: https://developer.ibm.com/exchanges/data/all/wikipedia-oriented-relatedness/
+      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-wikipedia-oriented-relatedness/1.0.2/wikipedia-oriented-relatedness.tar.gz
+      sha512sum: 270f0bb4711acff8f88e9ce10403a72ce13b8ad21205f61d41c17c520b1d30bccefcd2312db92c80ec525a8e8a926b2ff77f58d1e95efb0b17b945c8f5de4e7f
+      license: cc_by_sa_30
+      estimated_size: 3.4M
+      description: "Pairs of concepts from Wikipedia scored for their level of relatedness."
+      subdatasets:
+        full: 
+          name: IBM Debater® Wikipedia Oriented Relatedness complete dataset
+          format:
+            id: csv
+            options:
+              columns:
+                source_article_uri: 'string'
+                concept_1: 'string'
+                concept_2: 'string'
+                score: 'float'
+                concept_1_uri: 'string'
+                concept_2_uri: 'string'
+                train_test: 'string'
+          path: wikipedia_oriented_relatedness/WORD.csv

--- a/datasets.yaml
+++ b/datasets.yaml
@@ -184,40 +184,6 @@ datasets:
               columns:
                 DATE: 'datetime'
           path: noaa-weather-data-jfk-airport/jfk_weather_cleaned.csv
-  sentiment_compositions_lexicon:
-    "1.0.2":
-      name: IBM Debater® Sentiment Compositions Lexicon
-      published: 2019-10-01
-      homepage: https://developer.ibm.com/exchanges/data/all/sentiment-composition-lexicons/
-      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-sentiment-composition-lexicons/1.0.2/sentiment-composition-lexicons.tar.gz
-      sha512sum: 550da933b668270d890a4e12160202671894c357927e52250500e97b78965d7f3d4506396f9f21f50683a2fc54a4af5922f7fdd0ac7f01e4b5a2f1068451a519
-      license: cc_by_sa_30
-      estimated_size: 10M
-      description: "A dataset on the sentiment of phrases from the interaction between its constituents."
-      subdatasets:
-        unigrams:
-          name: Unigrams Sentiment Lexicon
-          description: "The unigrams sentiment lexicon"
-          format:
-            id: csv
-            options:
-              delimiter: ' '
-              columns:
-                UNIGRAM: 'string'
-                SENTIMENT_SCORE: 'float'
-          path: LEXICON_UG.txt
-        bigrams:
-          name: Bigrams Sentiment Lexicon
-          description: "The bigrams sentiment lexicon"
-          format:
-            id: csv
-            options:
-              delimiter: ' '
-              columns:
-                BIGRAM: 'string'
-                POS_TAG: 'string'
-                SENTIMENT_SCORE: 'float'
-          path: LEXICON_BG.txt
   taranaki-basin-curated-well-logs:
     "1.0.0":
       name: Taranaki Basin Curated Well Logs

--- a/datasets.yaml
+++ b/datasets.yaml
@@ -30,7 +30,7 @@ datasets:
       subdatasets:
         train:
           name: MC Query Train
-          description: Training set containing sentences retrieved by MC query
+          description: Sentences retrieved by the q_mc query on 70 train topics
           format:
             id: csv
             options:
@@ -45,7 +45,7 @@ datasets:
           path: q_mc_train.csv
         heldout:
           name: MC Query Heldout
-          description: Heldout set containing sentences retrieved by MC query
+          description: Sentences retrieved by the q_mc query on 30 heldout topics
           format:
             id: csv
             options:
@@ -60,7 +60,7 @@ datasets:
           path: q_mc_heldout.csv
         test:
           name: MC Query Test
-          description: Test set containing sentences retrieved by MC query
+          description: Sentences retrieved by the q_mc query on 50 test topics
           format:
             id: csv
             options:
@@ -73,9 +73,9 @@ datasets:
                 prefix: 'string'
                 url: 'string'
           path: q_mc_test.csv
-        dnn_test:
+        test_set:
           name: DNN Test
-          description: Dataset containing DNN score of each sentence and its gold label
+          description: Top predictions of our system along with their labels
           format:
             id: csv
             options:
@@ -102,7 +102,7 @@ datasets:
       subdatasets:
         unigrams:
           name: Unigrams
-          description: "Unigram Wikipedia Article Titles with their abstractness score"
+          description: "Concepts and abstractness scores for unigrams (single worded concepts)"
           format: csv
           options:
             columns:
@@ -111,7 +111,7 @@ datasets:
           path: prediction_unigrams.csv
         bigrams:
           name: Bigrams
-          description: "Bigram Wikipedia Article Titles with their abstractness score"
+          description: "Concepts and abstractness scores for bigrams (two word concepts)"
           format: csv
           options:
             columns:
@@ -120,7 +120,7 @@ datasets:
           path: prediction_bigrams.csv
         trigrams:
           name: Trigrams
-          description: "Trigram Wikipedia Article Titles with their abstractness score"
+          description: "Concepts and abstractness scores for trigrams (three word concepts)"
           format: csv
           options:
             columns:
@@ -197,7 +197,7 @@ datasets:
       subdatasets:
         unigrams:
           name: Unigrams Sentiment Lexicon
-          description: Unigrams with their sentiment score
+          description: "The unigrams sentiment lexicon"
           format:
             id: csv
             options:
@@ -208,7 +208,7 @@ datasets:
           path: LEXICON_UG.txt
         bigrams:
           name: Bigrams Sentiment Lexicon
-          description: Bigrams with their POS tag and sentiment score
+          description: "The bigrams sentiment lexicon"
           format:
             id: csv
             options:

--- a/datasets.yaml
+++ b/datasets.yaml
@@ -164,32 +164,6 @@ datasets:
           description: A full version of the raw dataset. Used to train MAX model – Named Entity Tagger.
           format: txt
           path: groningen_meaning_bank_modified/gmb_subset_full.txt
-  wikitext103:
-    "1.0.1":
-      name: WikiText-103
-      published: 2020-03-17
-      homepage: https://developer.ibm.com/exchanges/data/all/wikitext-103/
-      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-wikitext-103/1.0.1/wikitext-103.tar.gz
-      sha512sum: c8186919aa1840af6b734ea41abc580574ea8efe2fafda220f5d01002464d17566d84be5199b875136c9593f0e0678fb5d7c84bb2231de8b4151cb9c83fa2109
-      license: cc_by_30
-      estimated_size: 181M
-      description: "The WikiText-103 dataset is a collection of over 100 million tokens extracted from the set of verified ‘Good’ and ‘Featured’ articles on Wikipedia."
-      subdatasets:
-        train:
-          name: Train Tokens
-          description: Tokens in the training subset
-          format: txt
-          path: wikitext-103/wiki.train.tokens
-        valid:
-          name: Validation Tokens
-          description: Tokens in the validation subset
-          format: txt
-          path: wikitext-103/wiki.valid.tokens
-        test:
-          name: Test Tokens
-          description: Tokens in the testing subset
-          format: txt
-          path: wikitext-103/wiki.test.tokens
   noaa_jfk:
     "1.1.4":
       name: NOAA Weather Data – JFK Airport
@@ -370,3 +344,29 @@ datasets:
                 concept_2_uri: 'string'
                 train_test: 'string'
           path: WORD.csv
+  wikitext103:
+    "1.0.1":
+      name: WikiText-103
+      published: 2020-03-17
+      homepage: https://developer.ibm.com/exchanges/data/all/wikitext-103/
+      download_url: https://dax-cdn.cdn.appdomain.cloud/dax-wikitext-103/1.0.1/wikitext-103.tar.gz
+      sha512sum: c8186919aa1840af6b734ea41abc580574ea8efe2fafda220f5d01002464d17566d84be5199b875136c9593f0e0678fb5d7c84bb2231de8b4151cb9c83fa2109
+      license: cc_by_30
+      estimated_size: 181M
+      description: "The WikiText-103 dataset is a collection of over 100 million tokens extracted from the set of verified ‘Good’ and ‘Featured’ articles on Wikipedia."
+      subdatasets:
+        train:
+          name: Train Tokens
+          description: Tokens in the training subset
+          format: txt
+          path: wikitext-103/wiki.train.tokens
+        valid:
+          name: Validation Tokens
+          description: Tokens in the validation subset
+          format: txt
+          path: wikitext-103/wiki.valid.tokens
+        test:
+          name: Test Tokens
+          description: Tokens in the testing subset
+          format: txt
+          path: wikitext-103/wiki.test.tokens

--- a/datasets.yaml
+++ b/datasets.yaml
@@ -132,8 +132,9 @@ datasets:
           name: Unigrams Sentiment Lexicon
           description: Unigrams with their sentiment score
           format:
-            id: txt
+            id: csv
             options:
+              delimiter: ' '
               columns:
                 UNIGRAM: 'string'
                 SENTIMENT_SCORE: 'float'
@@ -142,8 +143,9 @@ datasets:
           name: Bigrams Sentiment Lexicon
           description: Bigrams with their POS tag and sentiment score
           format:
-            id: txt
+            id: csv
             options:
+              delimiter: ' '
               columns:
                 BIGRAM: 'string'
                 POS_TAG: 'string'

--- a/datasets.yaml
+++ b/datasets.yaml
@@ -23,7 +23,7 @@ datasets:
       published: 2019-07-29
       homepage: https://developer.ibm.com/exchanges/data/all/concept-abstractness/
       download_url: https://dax-cdn.cdn.appdomain.cloud/dax-concept-abstractness/1.0.2/concept-abstractness.tar.gz
-      sha512sum: 25cb76c0a8fdfc9cae7e050d4c2492bf055f97a20fa85690b9aaf7dcf965a705fc89e32aed7fbb6d418432e5368cb06fc3bb0f1ab85807fec8aef9df3965cc06 
+      sha512sum: 25cb76c0a8fdfc9cae7e050d4c2492bf055f97a20fa85690b9aaf7dcf965a705fc89e32aed7fbb6d418432e5368cb06fc3bb0f1ab85807fec8aef9df3965cc06
       license: cc_by_sa_30
       estimated_size: 3.6M
       description: "A set of concepts from Wikipedia rated for their degree of abstractness."
@@ -214,7 +214,7 @@ datasets:
       estimated_size: 3.4M
       description: "Pairs of concepts from Wikipedia scored for their level of relatedness."
       subdatasets:
-        full: 
+        full:
           name: IBM Debater® Wikipedia Oriented Relatedness complete dataset
           format:
             id: csv


### PR DESCRIPTION
Adds schemas for the following IBM Debater Datasets:

* IBM Debater® Concept Abstractness
* ~~IBM Debater® Sentiment Compositions Lexicon~~
* IBM Debater® Thematic Clustering of Sentences
* IBM Debater® Wikipedia Category Stance
* IBM Debater® Wikipedia Oriented Relatedness